### PR TITLE
fix: specify encoding to UTF-8

### DIFF
--- a/g2pw/api.py
+++ b/g2pw/api.py
@@ -80,15 +80,15 @@ class G2PWConverter:
 
         polyphonic_chars_path = os.path.join(model_dir, 'POLYPHONIC_CHARS.txt')
         monophonic_chars_path = os.path.join(model_dir, 'MONOPHONIC_CHARS.txt')
-        self.polyphonic_chars = [line.split('\t') for line in open(polyphonic_chars_path).read().strip().split('\n')]
-        self.monophonic_chars = [line.split('\t') for line in open(monophonic_chars_path).read().strip().split('\n')]
+        self.polyphonic_chars = [line.split('\t') for line in open(polyphonic_chars_path, 'r', encoding='utf-8').read().strip().split('\n')]
+        self.monophonic_chars = [line.split('\t') for line in open(monophonic_chars_path, 'r', encoding='utf-8').read().strip().split('\n')]
         self.labels, self.char2phonemes = get_char_phoneme_labels(self.polyphonic_chars) if self.config.use_char_phoneme else get_phoneme_labels(self.polyphonic_chars)
 
         self.chars = sorted(list(self.char2phonemes.keys()))
         self.pos_tags = TextDataset.POS_TAGS
 
         with open(os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                               'bopomofo_to_pinyin_wo_tune_dict.json'), 'r') as fr:
+                               'bopomofo_to_pinyin_wo_tune_dict.json'), 'r', encoding='utf-8') as fr:
             self.bopomofo_convert_dict = json.load(fr)
         self.style_convert_func = {
             'bopomofo': lambda x: x,
@@ -96,14 +96,14 @@ class G2PWConverter:
         }[style]
 
         with open(os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                               'char_bopomofo_dict.json'), 'r') as fr:
+                               'char_bopomofo_dict.json'), 'r', encoding='utf-8') as fr:
             self.char_bopomofo_dict = json.load(fr)
 
         self.enable_non_tradional_chinese = enable_non_tradional_chinese
         if self.enable_non_tradional_chinese:
             self.s2t_dict = {}
             for line in open(os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                    'bert-base-chinese_s2t_dict.txt'), 'r').read().strip().split('\n'):
+                    'bert-base-chinese_s2t_dict.txt'), 'r', encoding='utf-8').read().strip().split('\n'):
                 s_char, t_char = line.split('\t')
                 self.s2t_dict[s_char] = t_char
 


### PR DESCRIPTION
On Windows, the encoding needs to be specified. Otherwise, it would lead to encoding error, since Windows uses other encodings as their default encoding.