### PR TITLE
fix: allow num_workers=0 by using explicit None check

### DIFF
--- a/g2pw/api.py
+++ b/g2pw/api.py
@@ -76,7 +76,7 @@ class G2PWConverter:
 
         self.config = load_config(os.path.join(model_dir, 'config.py'), use_default=True)
 
-        self.num_workers = num_workers if num_workers else self.config.num_workers
+        self.num_workers = num_workers if num_workers is not None else self.config.num_workers
         self.batch_size = batch_size if batch_size else self.config.batch_size
         self.model_source = model_source if model_source else self.config.model_source
         self.turnoff_tqdm = turnoff_tqdm


### PR DESCRIPTION
`num_workers=0` is silently ignored because the truthiness check (`if num_workers`) treats `0` as falsy in python, falling back to `self.config.num_workers` (default `2`).

This means passing `num_workers=0` to disable DataLoader multiprocessing has no effect.

Replacing the check with `is not None` fixes this, so that `0` is correctly respected while `None` still falls back to the config default.